### PR TITLE
Fixed typos of Technical Concepts in Algorithmic Complexity

### DIFF
--- a/docs/data-abstraction/schedule-data-abstraction.md
+++ b/docs/data-abstraction/schedule-data-abstraction.md
@@ -211,10 +211,10 @@
 ???+ note "Technical Concepts"
 
     - **Random Access Machine**: model of computation in which steps are
-      executed sequentially one as a time
+      executed sequentially one at a time
     - **Best-Case Running Time**: minimum running time over all possible inputs
       of a given size
-    - **Worst-Case Running Time**: minimum running time over all possible inputs
+    - **Worst-Case Running Time**: maximum running time over all possible inputs
       of a given size
     - **Average-Case Running Time**: average (or, expected) running time over
       all possible inputs of a given size


### PR DESCRIPTION
Adjusted two definitions of Technical Concepts that had typos:
- "as a time" corrected to "at a time"  for Random Access Machine
- "minimum running time" corrected to "maximum running time" for Worst-Case Running Time